### PR TITLE
fix: unify generation code for consistent imports

### DIFF
--- a/pystructurizr/generator.py
+++ b/pystructurizr/generator.py
@@ -1,0 +1,37 @@
+import importlib
+import json
+import sys
+
+import click
+
+
+@click.command()
+@click.option('--view', prompt='Your view file (e.g. example.componentview)',
+              help='The view file to generate.')
+def dump(view: str):
+    try:
+        initial_modules = set(sys.modules.keys())
+        module = importlib.import_module(view)
+        imported_modules = set(sys.modules.keys()) - initial_modules
+        code = module.workspace.dump()
+        print(json.dumps({
+            "code": code,
+            "imported_modules": list(imported_modules)
+        }))
+    except ModuleNotFoundError:
+        # pylint: disable=raise-missing-from
+        raise click.BadParameter("Invalid view name. Make sure you don't include the .py file extension.")
+    except AttributeError:
+        # pylint: disable=raise-missing-from
+        raise click.BadParameter("Non-compliant view file: make sure it exports the PyStructurizr workspace.")
+
+
+@click.group()
+def cli():
+    pass
+
+
+cli.add_command(dump)
+
+if __name__ == '__main__':
+    cli()


### PR DESCRIPTION
There was an issue with inconsistent importing of views due to the fact that `pystructurizr dev --view <>` would run a child process with `python -m` vs. `pystructurizr dump --view <>` running directly. `importlib.import_module` behaves differently when the executable is `python` vs. a python module directly.

The symptoms of the issue appeared as follows:
```
➜  diagrams: pipenv run pystructurizr dump --view myview              
Usage: pystructurizr dump [OPTIONS]
Try 'pystructurizr dump --help' for help.

Error: Invalid value: Invalid view name. Make sure you don't include the .py file extension.
➜  diagrams: pipenv run python -m pystructurizr.cli dump --view myview
workspace {
  model {
```

Individual python files were unimportable when using `dump` directly, as the executable was the CLI, and `importlib.import_module` would not import. However, when using the `python -m` invocation, the executable is `python`, which allows importing of files as modules.

-------

This change unifies the code generation as a distinct executable submodule, and removes the "naked" DSL generator code. I also cleaned up the calling code a touch, as having the unified `tuple[dict, list[str]]` return typing allowed it. I also patched a couple instances of broken typing.