### PR TITLE
feat: add support for docs directive

### DIFF
--- a/pystructurizr/cli.py
+++ b/pystructurizr/cli.py
@@ -17,10 +17,10 @@ from .cloudstorage import CloudStorage, create_cloud_storage
 @click.option('--as-json', is_flag=True, default=False,
               help='Dumps the generated code and the imported modules as a json object')
 @click.option(
-    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
-    is_flag=True, default=True)
-def dump(view, as_json, docs: bool):
-    diagram_code, imported_modules = generate_diagram_code_in_child_process(view, docs)
+    "--directives", help="Flag to add extra directives (i.e. !docs) or omit",
+    is_flag=True, default=False)
+def dump(view, as_json, directives: bool):
+    diagram_code, imported_modules = generate_diagram_code_in_child_process(view, directives)
     if as_json:
         print(json.dumps({
             "code": diagram_code,

--- a/pystructurizr/cli.py
+++ b/pystructurizr/cli.py
@@ -33,10 +33,7 @@ def dump(view, as_json, docs: bool):
 @click.command()
 @click.option('--view', prompt='Your view file (e.g. examples.single_file_example)',
               help='The view file to develop.')
-@click.option(
-    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
-    is_flag=True, default=False)
-def dev(view, docs: bool):
+def dev(view):
     click.echo(f"Setting up live preview of view {view}...")
     # Prep the /tmp/pystructurizr folder
     tmp_folder = ensure_tmp_folder_exists()
@@ -46,7 +43,7 @@ def dev(view, docs: bool):
 
     async def async_behavior():
         print("Generating diagram...")
-        diagram_code, imported_modules = generate_diagram_code_in_child_process(view, docs)
+        diagram_code, imported_modules = generate_diagram_code_in_child_process(view, False)
         await generate_svg(diagram_code, tmp_folder)
         return imported_modules
 
@@ -69,13 +66,10 @@ def dev(view, docs: bool):
               help='The name of the bucket to use on Google Cloud Storage.')
 @click.option('--object-name', prompt='Name of the object on Google Cloud Storage',
               help='The name of the object to use on Google Cloud Storage.')
-@click.option(
-    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
-    is_flag=True, default=False)
-def build(view, gcs_credentials, bucket_name, object_name, docs: bool):
+def build(view, gcs_credentials, bucket_name, object_name):
     async def async_behavior():
         # Generate diagram
-        diagram_code, _ = generate_diagram_code_in_child_process(view, docs)
+        diagram_code, _ = generate_diagram_code_in_child_process(view, False)
         tmp_folder = ensure_tmp_folder_exists()
 
         # Generate SVG

--- a/pystructurizr/cli.py
+++ b/pystructurizr/cli.py
@@ -16,8 +16,11 @@ from .cloudstorage import CloudStorage, create_cloud_storage
               help='The view file to generate.')
 @click.option('--as-json', is_flag=True, default=False,
               help='Dumps the generated code and the imported modules as a json object')
-def dump(view, as_json):
-    diagram_code, imported_modules = generate_diagram_code_in_child_process(view)
+@click.option(
+    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
+    is_flag=True, default=True)
+def dump(view, as_json, docs: bool):
+    diagram_code, imported_modules = generate_diagram_code_in_child_process(view, docs)
     if as_json:
         print(json.dumps({
             "code": diagram_code,
@@ -30,7 +33,10 @@ def dump(view, as_json):
 @click.command()
 @click.option('--view', prompt='Your view file (e.g. examples.single_file_example)',
               help='The view file to develop.')
-def dev(view):
+@click.option(
+    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
+    is_flag=True, default=False)
+def dev(view, docs: bool):
     click.echo(f"Setting up live preview of view {view}...")
     # Prep the /tmp/pystructurizr folder
     tmp_folder = ensure_tmp_folder_exists()
@@ -40,7 +46,7 @@ def dev(view):
 
     async def async_behavior():
         print("Generating diagram...")
-        diagram_code, imported_modules = generate_diagram_code_in_child_process(view)
+        diagram_code, imported_modules = generate_diagram_code_in_child_process(view, docs)
         await generate_svg(diagram_code, tmp_folder)
         return imported_modules
 
@@ -63,10 +69,13 @@ def dev(view):
               help='The name of the bucket to use on Google Cloud Storage.')
 @click.option('--object-name', prompt='Name of the object on Google Cloud Storage',
               help='The name of the object to use on Google Cloud Storage.')
-def build(view, gcs_credentials, bucket_name, object_name):
+@click.option(
+    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
+    is_flag=True, default=False)
+def build(view, gcs_credentials, bucket_name, object_name, docs: bool):
     async def async_behavior():
         # Generate diagram
-        diagram_code, _ = generate_diagram_code_in_child_process(view)
+        diagram_code, _ = generate_diagram_code_in_child_process(view, docs)
         tmp_folder = ensure_tmp_folder_exists()
 
         # Generate SVG

--- a/pystructurizr/cli_helper.py
+++ b/pystructurizr/cli_helper.py
@@ -8,13 +8,13 @@ import click
 import httpx
 
 
-def generate_diagram_code_in_child_process(view: str, docs: bool) -> tuple[dict, list[str]]:
+def generate_diagram_code_in_child_process(view: str, directives: bool) -> tuple[dict, list[str]]:
     def run_child_process():
         # Run a separate Python script as a child process
-        if docs:
-            output = subprocess.check_output([sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view, "--docs"])
-        else:
-            output = subprocess.check_output([sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view])
+        executable = [sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view]
+        if directives:
+            executable.append("--directives")
+        output = subprocess.check_output(executable)
         return output.decode().strip()
 
     # Run the child process and capture its output

--- a/pystructurizr/cli_helper.py
+++ b/pystructurizr/cli_helper.py
@@ -8,10 +8,13 @@ import click
 import httpx
 
 
-def generate_diagram_code_in_child_process(view: str) -> tuple[dict, list[str]]:
+def generate_diagram_code_in_child_process(view: str, docs: bool) -> tuple[dict, list[str]]:
     def run_child_process():
         # Run a separate Python script as a child process
-        output = subprocess.check_output([sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view])
+        if docs:
+            output = subprocess.check_output([sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view, "--docs"])
+        else:
+            output = subprocess.check_output([sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view])
         return output.decode().strip()
 
     # Run the child process and capture its output

--- a/pystructurizr/generator.py
+++ b/pystructurizr/generator.py
@@ -8,12 +8,15 @@ import click
 @click.command()
 @click.option('--view', prompt='Your view file (e.g. example.componentview)',
               help='The view file to generate.')
-def dump(view: str):
+@click.option(
+    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
+    is_flag=True, default=False)
+def dump(view: str, docs: bool):
     try:
         initial_modules = set(sys.modules.keys())
         module = importlib.import_module(view)
         imported_modules = set(sys.modules.keys()) - initial_modules
-        code = module.workspace.dump()
+        code = module.workspace.dump(with_docs=docs)
         print(json.dumps({
             "code": code,
             "imported_modules": list(imported_modules)

--- a/pystructurizr/generator.py
+++ b/pystructurizr/generator.py
@@ -4,19 +4,22 @@ import sys
 
 import click
 
+from pystructurizr.dsl import Dumper
+
 
 @click.command()
 @click.option('--view', prompt='Your view file (e.g. example.componentview)',
               help='The view file to generate.')
 @click.option(
-    "--docs", prompt="Flag to add the !docs directive or omit", help="Flag to add the !docs directive or omit",
+    "--directives", help="Flag to add extra directives (i.e. !docs) or omit",
     is_flag=True, default=False)
-def dump(view: str, docs: bool):
+def dump(view: str, directives: bool):
     try:
         initial_modules = set(sys.modules.keys())
         module = importlib.import_module(view)
         imported_modules = set(sys.modules.keys()) - initial_modules
-        code = module.workspace.dump(with_docs=docs)
+        dumper = Dumper(with_directives=directives)
+        code = module.workspace.dump(dumper=dumper)
         print(json.dumps({
             "code": code,
             "imported_modules": list(imported_modules)


### PR DESCRIPTION
Adds support for the [`!docs`](https://github.com/structurizr/dsl/blob/master/docs/language-reference.md#documentation) directive. This directive is valid for Workspaces, Software Systems, and Containers. However, `kroki.io` doesn't support `!docs` (obviously), so we need to be able to toggle whether we include these additional directives in the `dump`. 

Unfortunately,  because Models contain both `Person`s and `SoftwareSystem`s, to fit the current implementation, `Person.dump` needs to accept `with_docs` argument and do nothing with it, while `SoftwareSystem.dump` acts on the argument. I don't like this, and am open to suggestions on a better implementation. I can see this getting worse when `Group` is supported, as it would also be an `Element` that needs to accept `with_docs`. There's also the additional complication of future `!adrs` support, etc.

-------------

This enables users to include `docs=docs` kwarg in any of the supported objects, run `pystructurizr dump > workspace.dsl` and then serve the `dsl` through a rendering engine of their choice that supports `!docs`. For example, I'm choosing to have the following file structure:

- docs
  - doc.md
- workspace.dsl

`workspace.dsl` includes directives such as `!doc docs` which when served via `docker run -it --rm -v $(pwd):/var/model -p 8080:8080 ghcr.io/avisi-cloud/structurizr-site-generatr serve -w workspace.dsl` imports the `docs` directory as appropriate.