### PR TITLE
fix: type inaccuracies

### DIFF
--- a/pystructurizr/dsl.py
+++ b/pystructurizr/dsl.py
@@ -61,7 +61,7 @@ class Element:
         self.relationships = []
         self.instname = Identifier.make_identifier(name)
 
-    def uses(self, destination: str, description: Optional[str]=None, technology: Optional[str]=None) -> 'Relationship':
+    def uses(self, destination: 'Element', description: Optional[str]=None, technology: Optional[str]=None) -> 'Relationship':
         relationship = Relationship(self, destination, description, technology)
         self.relationships.append(relationship)
         return relationship
@@ -423,7 +423,7 @@ class Workspace:
     def __exit__(self, exc_type, exc_val, exc_tb):
         pass
 
-    def dump(self, dumper: Dumper = Dumper()) -> None:
+    def dump(self, dumper: Dumper = Dumper()) -> str:
         dumper.add('workspace {')
         dumper.indent()
 


### PR DESCRIPTION
Love the library, but I had some type errors when attempting to use it. 


- `Element.uses()` takes in a `destination` expecting the `destination` to also be an `Element`, but is typed as a string.
- `Workspace.dump()` returns a string, but is typed to return `None`.