### PR TITLE
Update cli_helper.py

### DIFF
--- a/pystructurizr/cli_helper.py
+++ b/pystructurizr/cli_helper.py
@@ -1,3 +1,4 @@
+from typing import List, Dict, Tuple
 import json
 import os
 import subprocess
@@ -8,7 +9,7 @@ import click
 import httpx
 
 
-def generate_diagram_code_in_child_process(view: str) -> tuple[dict, list[str]]:
+def generate_diagram_code_in_child_process(view: str) -> Tuple[Dict, List[str]]:
     def run_child_process():
         # Run a separate Python script as a child process
         output = subprocess.check_output([sys.executable, "-m", "pystructurizr.generator", "dump", "--view", view])
@@ -20,7 +21,7 @@ def generate_diagram_code_in_child_process(view: str) -> tuple[dict, list[str]]:
     return result['code'], result['imported_modules']
 
 
-async def generate_svg(diagram_code: dict, tmp_folder: str) -> str:
+async def generate_svg(diagram_code: Dict, tmp_folder: str) -> str:
     url = "https://kroki.io/structurizr/svg"
     async with httpx.AsyncClient() as client:
         resp = await client.post(url, data=diagram_code)


### PR DESCRIPTION
Leverage Type Aliases from the `typing` module.

This avoids throwing an error in python 3.8 when calling `pystructurizr dev --view <filename>`:

```
Traceback (most recent call last):
  File "/path/to/venv/bin/pystructurizr", line 5, in <module>
    from pystructurizr.cli import cli
  File "/path/to/venv/lib/python3.8/site-packages/pystructurizr/cli.py", line 9, in <module>
    from .cli_helper import (ensure_tmp_folder_exists, generate_diagram_code_in_child_process, generate_svg)
  File "/path/to/venv/lib/python3.8/site-packages/pystructurizr/cli_helper.py", line 11, in <module>
    def generate_diagram_code_in_child_process(view: str) -> tuple[dict, list[str]]:
TypeError: 'type' object is not subscriptable
```