### PR TITLE
Do not add include * when exclude or include has values

### DIFF
--- a/pystructurizr/dsl.py
+++ b/pystructurizr/dsl.py
@@ -356,7 +356,8 @@ class View:
         dumper.indent()
         if self.description:
             dumper.add(f'description "{self.description}"')
-        dumper.add('include *')
+        if not self.includes and not self.excludes:
+          dumper.add('include *')
         for include in self.includes:
             dumper.add(f'include {include.instname}')
         for exclude in self.excludes:


### PR DESCRIPTION
Hi, 

Great tool - thanks a bunch!

I was a bit surprised to find the `dumper.add('include *')` line in the `View` dump function. 

As far as I understand it, this means that me appending to `view.includes`. And for a big system it will quite a lot of things to `view.exlcude.append` 

Here's a suggestion for a change - but please give me some feedback on this as I might not have the pieces clear for me