### PR TITLE
Refactoring build to have a subcommand upload

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,4 @@ build/
 gcs_credentials.json
 
 .idea/
+.python-version

--- a/README.md
+++ b/README.md
@@ -77,15 +77,36 @@ Finally, there's a development mode so you can get live preview of the diagram y
 ## Usage
 
 ### Convert to Structurizr DSL
-```pystructurizr dump --view <path_to_view_file>```
+
+```bash
+pystructurizr dump --view <path_to_view_file>
+```
 
 ### Live preview 
-```pystructurizr dev --view <path_to_view_file>```
+```
+pystructurizr dev --view <path_to_view_file>
+```
 
-### Convert to SVG and upload to cloud storage
-```pystructurizr build --view <path_to_view_file> --gcs-credentials <path_to_credentials_json_file> --bucket-name <string> --object-name <string>```
+### Convert to SVG
+
+Build a `VIEW` into an SVG and save it to `FILE_PATH`.
+
+`FILE_PATH` can be a directory or a file name. If it is a directory, the file name will be the view name.
+
+Can be chained with `upload` to upload the resulting file to a cloud storage provider.
+
+```
+pystructurizr build <dotted_path_to_view_file> <path_to_output_file>
+```
 
 Note that this command uses kroki.io under the hood to generate your SVG file. The benefit is that you don't need to install any tools that understand Structurizr DSL on your machine. The downside is that your diagram code is sent to an online service.
+
+
+### Build And upload to cloud storage
+```
+pystructurizr build <dotted_path_to_view_file> <path_to_output_file> upload --gcs-credentials <path_to_credentials_json_file> --bucket-name <string> --object-name <string>
+```
+
 
 ## License
 

--- a/examples/module_example/README.md
+++ b/examples/module_example/README.md
@@ -17,5 +17,5 @@ $ pystructurizr dev --view examples.module_example.systemlandscapeview
 ```
 or 
 ```
-$ pystructurizr build --view examples.module_example.systemlandscapeview --gcs-credentials <...> --bucket-name <...> --object-name <...>
+$ pystructurizr build examples.module_example.systemlandscapeview img/ --gcs-credentials <...> --bucket-name <...> --object-name <...>
 ```

--- a/pystructurizr/cli.py
+++ b/pystructurizr/cli.py
@@ -1,12 +1,13 @@
 import asyncio
 import json
-import os
 import shutil
 import subprocess
+import tempfile
+from pathlib import Path
 
 import click
 
-from .cli_helper import (ensure_tmp_folder_exists, generate_diagram_code_in_child_process, generate_svg)
+from .cli_helper import (generate_diagram_code_in_child_process, generate_svg)
 from .cli_watcher import observe_modules
 from .cloudstorage import CloudStorage, create_cloud_storage
 
@@ -19,12 +20,12 @@ from .cloudstorage import CloudStorage, create_cloud_storage
 def dump(view, as_json):
     diagram_code, imported_modules = generate_diagram_code_in_child_process(view)
     if as_json:
-        print(json.dumps({
+        click.echo(json.dumps({
             "code": diagram_code,
             "imported_modules": list(imported_modules)
         }))
     else:
-        print(diagram_code)
+        click.echo(diagram_code)
 
 
 @click.command()
@@ -32,50 +33,86 @@ def dump(view, as_json):
               help='The view file to develop.')
 def dev(view):
     click.echo(f"Setting up live preview of view {view}...")
-    # Prep the /tmp/pystructurizr folder
-    tmp_folder = ensure_tmp_folder_exists()
-    current_script_path = os.path.abspath(__file__)
-    index_html = os.path.join(os.path.dirname(current_script_path), 'index.html')
-    shutil.copy(index_html, f"{tmp_folder}/index.html")
+    with tempfile.TemporaryDirectory() as tmp_folder:
+        current_script_path = Path(__file__).absolute()
+        index_html = current_script_path.parent / 'index.html'
+        shutil.copy(index_html, f"{tmp_folder}/index.html")
 
-    async def async_behavior():
-        print("Generating diagram...")
-        diagram_code, imported_modules = generate_diagram_code_in_child_process(view)
-        await generate_svg(diagram_code, tmp_folder)
-        return imported_modules
+        async def async_behavior():
+            click.echo("Generating diagram...")
+            diagram_code, imported_modules = generate_diagram_code_in_child_process(view)
+            await generate_svg(diagram_code, tmp_folder)
+            return imported_modules
 
-    async def observe_loop():
-        modules_to_watch = await async_behavior()
-        click.echo("Launching webserver...")
-        # pylint: disable=consider-using-with
-        subprocess.Popen(f"httpwatcher --root {tmp_folder} --watch {tmp_folder}", shell=True)
-        await observe_modules(modules_to_watch, async_behavior)
+        async def observe_loop():
+            modules_to_watch = await async_behavior()
+            click.echo("Launching webserver...")
+            # pylint: disable=consider-using-with
+            subprocess.Popen(f"httpwatcher --root {tmp_folder} --watch {tmp_folder}", shell=True)
+            await observe_modules(modules_to_watch, async_behavior)
 
-    asyncio.run(observe_loop())
+        asyncio.run(observe_loop())
 
 
-@click.command()
-@click.option('--view', prompt='Your view file (e.g. examples.single_file_example)',
-              help='The view file to generate and upload to cloud storage.')
+@click.group(chain=True, invoke_without_command=True)
+@click.argument('view')
+@click.argument('file-path', type=click.Path(exists=False))
+@click.pass_context
+def build(ctx, view, file_path):
+    """Build VIEW into an SVG and save it to FILE_PATH.
+
+    FILE_PATH can be a directory or a file name. If it is a directory, the file name will be the view name.
+
+    Can be chained with `upload` to upload the resulting file to a cloud storage provider.
+    """
+    with tempfile.TemporaryDirectory() as tmp_folder:
+        async def async_behavior():
+            # Generate diagram
+            diagram_code, _ = generate_diagram_code_in_child_process(view)
+
+            # Generate SVG
+            temp_svg_file_path = await generate_svg(diagram_code, tmp_folder)
+
+            svg_file_path = Path(file_path)
+
+            # if we only have a directory name, output should include the view name
+            if svg_file_path.is_file():
+                base_dir = svg_file_path.parent
+            else:
+                base_dir = svg_file_path
+                diagram_name = view.replace(".", "_")
+                svg_file_path = svg_file_path / f"{diagram_name}.svg"
+
+            # Ensure that the directory exists
+            base_dir.mkdir(parents=True, exist_ok=True)
+
+            # Move it to the requested file name
+            shutil.move(temp_svg_file_path, svg_file_path)
+
+            ctx.ensure_object(dict)
+            ctx.obj['svg_file_path'] = svg_file_path
+            click.echo(svg_file_path)
+
+        asyncio.run(async_behavior())
+
+
+@build.command()
 @click.option('--gcs-credentials', prompt='Path to json file containing Google Cloud Storage credentials', type=click.Path(exists=True),
               help='Path to the credentials.json file for Google Cloud Storage.')
 @click.option('--bucket-name', prompt='Name of the bucket on Google Cloud Storage',
               help='The name of the bucket to use on Google Cloud Storage.')
 @click.option('--object-name', prompt='Name of the object on Google Cloud Storage',
               help='The name of the object to use on Google Cloud Storage.')
-def build(view, gcs_credentials, bucket_name, object_name):
+@click.pass_context
+def upload(ctx, gcs_credentials, bucket_name, object_name):
     async def async_behavior():
-        # Generate diagram
-        diagram_code, _ = generate_diagram_code_in_child_process(view)
-        tmp_folder = ensure_tmp_folder_exists()
-
-        # Generate SVG
-        svg_file_path = await generate_svg(diagram_code, tmp_folder)
+        svg_file_path = ctx.obj['svg_file_path']
+        click.echo(f"Uploading {svg_file_path}")
 
         # Upload it to the requested cloud storage provider
         cloud_storage = create_cloud_storage(CloudStorage.Provider.GCS, gcs_credentials)
         svg_file_url = cloud_storage.upload_file(svg_file_path, bucket_name, object_name)
-        print(svg_file_url)
+        click.echo(svg_file_url)
 
     asyncio.run(async_behavior())
 

--- a/pystructurizr/cli_helper.py
+++ b/pystructurizr/cli_helper.py
@@ -1,5 +1,4 @@
 import json
-import os
 import subprocess
 import sys
 
@@ -36,9 +35,3 @@ async def generate_svg(diagram_code: dict, tmp_folder: str) -> str:
         await svg_file.write(resp.text)
 
     return svg_file_path
-
-
-def ensure_tmp_folder_exists() -> str:
-    tmp_folder = "/tmp/pystructurizr"
-    os.makedirs(tmp_folder, exist_ok=True)
-    return tmp_folder


### PR DESCRIPTION
Hi, I've worked on #11 to get a local build setup.

I've made a few small refactorings:

- Using [`tempfile.TemporaryDirectory`](https://docs.python.org/3/library/tempfile.html#tempfile.TemporaryDirectory) instead of custom `ensure_tmp_folder_exists` to get a truly temporary directory for the build.
- Using [`click.echo`](https://click.palletsprojects.com/en/8.1.x/api/#click.echo) instead of `print` for better console compatibility.
- Using [`Path`](https://docs.python.org/3/library/pathlib.html) instead of `os` for improved readability.
- Split the command `build` into `build` and `upload`, the latter as a subcommand that can be chained.

### Usage

#### Build

```
❯ pystructurizr build --help
Usage: pystructurizr build [OPTIONS] VIEW FILE_PATH COMMAND1 [ARGS]...
                           [COMMAND2 [ARGS]...]...

  Build VIEW into an SVG and save it to FILE_PATH.

  FILE_PATH can be a directory or a file name. If it is a directory, the
  file name will be the view name.

  Can be chained with `upload` to upload the resulting file to a cloud
  storage provider.

Options:
  --help  Show this message and exit.

Commands:
  upload
  ```

Example:
```
pystructurizr build examples.module_example.systemlandscapeview img/
```

#### Upload

```
❯ pystructurizr build examples.module_example.systemlandscapeview img/ upload
 --help
img/examples_module_example_systemlandscapeview.svg
Usage: pystructurizr build VIEW FILE_PATH upload [OPTIONS]

Options:
  --gcs-credentials PATH  Path to the credentials.json file for Google Cloud
                          Storage.
  --bucket-name TEXT      The name of the bucket to use on Google Cloud
                          Storage.
  --object-name TEXT      The name of the object to use on Google Cloud
                          Storage.
  --help                  Show this message and exit.
```

Example:

```
pystructurizr build examples.module_example.systemlandscapeview img/ upload --gcs-credentials <...> --bucket-name <...> --object-name <...>
```

